### PR TITLE
Fix card component css class application

### DIFF
--- a/apps/dashboard/src/app/globals.css
+++ b/apps/dashboard/src/app/globals.css
@@ -1,6 +1,9 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@source "../**/*.{js,ts,jsx,tsx}";
+@source "../../../../packages/app-core/src/**/*.{js,ts,jsx,tsx}";
+
 @custom-variant dark (&:is(.dark *));
 
 


### PR DESCRIPTION
Add Tailwind CSS v4 `@source` directives to `globals.css` to enable scanning of shared package components.

Previously, Tailwind CSS was not applying styles to components like `card.tsx` after they were moved to the `packages/app-core/src` shared package. This was because Tailwind's content scan was limited to the `dashboard` app's local files. Adding `@source` directives ensures that Tailwind now correctly identifies and generates CSS utilities for classes used in the shared package, resolving the styling issue without needing to manually add classes to `global.css`.

---
<a href="https://cursor.com/background-agent?bcId=bc-015615a3-2f90-489e-ba53-d8b1bb59f5ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-015615a3-2f90-489e-ba53-d8b1bb59f5ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

